### PR TITLE
Introduce availableStudyGuard

### DIFF
--- a/Site/webapp/js/client/component-wrappers/index.js
+++ b/Site/webapp/js/client/component-wrappers/index.js
@@ -222,12 +222,12 @@ function availableStudyGuard(getRecordClassLoadingSelector, getStudyIdSelector, 
 
       const allValidStudies = studies[0];
 
-      const study = allValidStudies && allValidStudies.find(
+      const studyIsAvailable = allValidStudies.some(
         ({ id, disabled }) => id === targetId && !disabled
       );
 
       return (
-        targetId != null && study == null
+        targetId != null && !studyIsAvailable
           ? <NotFound />
           : <div>
               {defaultElement}

--- a/Site/webapp/js/client/component-wrappers/index.js
+++ b/Site/webapp/js/client/component-wrappers/index.js
@@ -220,7 +220,7 @@ function availableStudyGuard(getRecordClassLoadingSelector, getStudyIdSelector, 
         );
       }
 
-      const allValidStudies = studies == null ? undefined : studies[0];
+      const allValidStudies = studies[0];
 
       const study = allValidStudies && allValidStudies.find(
         ({ id, disabled }) => id === targetId && !disabled

--- a/Site/webapp/js/client/component-wrappers/index.js
+++ b/Site/webapp/js/client/component-wrappers/index.js
@@ -56,8 +56,47 @@ export default {
     }),
     QuestionWizardController
   ),
-  DownloadFormController: withRestrictionHandler(Action.downloadPage, state => state.downloadForm.recordClass),
-  RecordController: withRestrictionHandler(Action.recordPage, state => state.record.recordClass),
+  DownloadFormController: compose(
+    withRestrictionHandler(Action.downloadPage, state => state.downloadForm.recordClass),
+    availableStudyGuard(
+      downloadFormIsLoading,
+      state => {
+        const { recordClass, resultType } = state.downloadForm;
+
+        if (
+          downloadFormIsLoading(state) ||
+          resultType == null ||
+          resultType.type !== 'answerSpec'
+        ) {
+          return undefined;
+        }
+
+        const primaryKey = resultType.answerSpec.searchConfig.parameters.primaryKeys;
+
+        return getStudyIdFromRecordClassAndPrimaryKey(
+          recordClass,
+          primaryKey
+        );
+      },
+      StudyNotFoundPage
+    )
+  ),
+  RecordController: compose(
+    withRestrictionHandler(Action.recordPage, state => state.record.recordClass),
+    availableStudyGuard(
+      recordPageIsLoading,
+      (state, props) => {
+        const recordClass = state.record.recordClass;
+        const primaryKey = props.ownProps.primaryKey;
+
+        return getStudyIdFromRecordClassAndPrimaryKey(
+          recordClass,
+          primaryKey
+        );
+      },
+      StudyNotFoundPage
+    )
+  ),
   // FIXME Add restricted results panel
   RecordHeading,
   RecordTable,
@@ -196,4 +235,32 @@ function availableStudyGuard(getRecordClassLoadingSelector, getStudyIdSelector, 
       );
     }
   }
+}
+
+function StudyNotFoundPage() {
+  useSetDocumentTitle('Page not found');
+
+  return <NotFoundController />;
+}
+
+function getStudyIdFromRecordClassAndPrimaryKey(recordClass, primaryKey) {
+  return recordClass == null
+    ? undefined
+    : recordClass.urlSegment === 'dataset'
+    ? primaryKey
+    : isStudyRecordClass(recordClass)
+    ? getIdFromRecordClassName(recordClass.fullName)
+    : undefined;
+}
+
+// TODO: Move to an appropriate utility directory/repo
+function recordPageIsLoading(state) {
+  return state.record.isLoading;
+}
+
+// TODO: Move to an appropriate utility directory/repo
+// FIXME: The Download form redux should set "isLoading" to false
+// FIXME: when an error occurs
+function downloadFormIsLoading(state) {
+  return state.downloadForm.isLoading && state.downloadForm.error;
 }


### PR DESCRIPTION
This PR introduces a new "higher-order component wrapper": `availableStudyGuard`, which renders the wrapped component iff the component is not associated with a restricted study. (That is, a study which unavailable/disabled in the project.)