### PR TITLE
Fix race condition for DataRestrictionDaemon

### DIFF
--- a/Site/package.json
+++ b/Site/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@veupathdb/wdk-client": "^0.1.1-alpha.12",
-    "@veupathdb/web-common": "^0.1.3"
+    "@veupathdb/web-common": "^0.1.5"
   },
   "resolutions": {
     "react": "16",

--- a/Site/package.json
+++ b/Site/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@veupathdb/wdk-client": "^0.1.1-alpha.12",
-    "@veupathdb/web-common": "^0.1.1-alpha.11"
+    "@veupathdb/web-common": "^0.1.3"
   },
   "resolutions": {
     "react": "16",

--- a/Site/webapp/js/client/component-wrappers/IndexController.jsx
+++ b/Site/webapp/js/client/component-wrappers/IndexController.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import CardBasedIndexController from '@veupathdb/web-common/lib/controllers/CardBasedIndexController';
+import { usePermissions } from '@veupathdb/web-common/lib/hooks/permissions';
 
 import { getStaticSiteData } from '../selectors/siteData';
-import getHomeContent from '../data/homeContent';
+import makeGetHomeContent from '../data/homeContent';
 
 const searchesUserEmails = [ 'eupathdb@gmail.com' ];
 
 export default function IndexControllerWrapper() {
   return function IndexController() {
+    const permissionsValue = usePermissions();
+
+    const getHomeContent = useMemo(
+      () => makeGetHomeContent(permissionsValue),
+      [permissionsValue]
+    );
+
     return (
       <CardBasedIndexController
         searchesUserEmails={searchesUserEmails}

--- a/Site/webapp/js/client/component-wrappers/index.js
+++ b/Site/webapp/js/client/component-wrappers/index.js
@@ -109,7 +109,6 @@ export default {
     return () => <DefaultComponent specialInstructions={specialInstructions} />;
   },
   DownloadLink: withPermissions,
-  DataRestrictionDaemon: withPermissions,
   Page
 }
 

--- a/Site/webapp/js/client/data/homeContent.js
+++ b/Site/webapp/js/client/data/homeContent.js
@@ -2,12 +2,9 @@ import { StudyCard } from '@veupathdb/web-common/lib/App/Studies';
 import { SearchCard } from '@veupathdb/web-common/lib/App/Searches';
 import { ImageCard } from '@veupathdb/web-common/lib/App/ImageCard';
 
-import { withPermissions } from '@veupathdb/web-common/lib/components/Permissions';
 import { studyMatchPredicate, studyFilters } from '@veupathdb/web-common/lib/util/homeContent';
 
-const ClinEpiStudyCard = withPermissions(StudyCard);
-
-export default ({ studies, searches, visualizations }) => ([
+export default permissionsValue => ({ studies, searches, visualizations }) => ([
   {
     title: 'Explore the Studies',
     contentType: 'StudyCardList',
@@ -15,13 +12,14 @@ export default ({ studies, searches, visualizations }) => ([
     filters: studyFilters(studies),
     filtersLabel: 'disease',
     items: studies.entities,
-    isLoading: studies.loading,
+    isLoading: studies.loading || permissionsValue.loading,
     isExpandable: true,
     tableViewLink: '/search/dataset/Studies/result',
-    cardComponent: ClinEpiStudyCard,
+    cardComponent: StudyCard,
     getSearchStringForItem: item => 
       item.searchString,
-    matchPredicate: studyMatchPredicate
+    matchPredicate: studyMatchPredicate,
+    permissions: permissionsValue.permissions
   },
   {
     title: 'Explore Example Searches',

--- a/Site/yarn.lock
+++ b/Site/yarn.lock
@@ -323,10 +323,10 @@
     spin.js "^4.0.0"
     uuid "^8.1.0"
 
-"@veupathdb/web-common@^0.1.1-alpha.11":
-  version "0.1.1-alpha.11"
-  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.1-alpha.11.tgz#66598c0433755ef7961571d9939c0b5932a76610"
-  integrity sha512-0oIKjRjaiO27T1JFEbRRqeDYwHqMmrtOxrCbkmvIytkeaONiiLXNWNyhEIs9UnWtYDebYX9+LVMCQUD6v9BXCA==
+"@veupathdb/web-common@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.3.tgz#a2909ddb8e66260c952ad031722d291c62f97347"
+  integrity sha512-BhrlQwI2gX25obKp0OucgUBi7TMVaodgAu/lVrlX+QIkXGvq6136njUEUpPpDdlgb2fRXMjDAF6vftL62prbMg==
   dependencies:
     custom-event-polyfill "^1.0.7"
     md5 "^2.3.0"
@@ -921,9 +921,9 @@ value-equal@^1.0.1:
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 whatwg-fetch@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
-  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 yaml@^1.7.2:
   version "1.10.0"

--- a/Site/yarn.lock
+++ b/Site/yarn.lock
@@ -323,10 +323,10 @@
     spin.js "^4.0.0"
     uuid "^8.1.0"
 
-"@veupathdb/web-common@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.3.tgz#a2909ddb8e66260c952ad031722d291c62f97347"
-  integrity sha512-BhrlQwI2gX25obKp0OucgUBi7TMVaodgAu/lVrlX+QIkXGvq6136njUEUpPpDdlgb2fRXMjDAF6vftL62prbMg==
+"@veupathdb/web-common@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@veupathdb/web-common/-/web-common-0.1.5.tgz#3d664a8d815fb9731433fe0895fe7e4810f334c2"
+  integrity sha512-SSHbv3ZIho3xmkIY9prkpw/S5EKRumZj05RxfjtLkwBKiZ9k31Nd6owBD/ykmF3rwOwm4UST1PQMv3jL23zKuA==
   dependencies:
     custom-event-polyfill "^1.0.7"
     md5 "^2.3.0"


### PR DESCRIPTION
This PR:

1. Removes the wrapping of `DataRestrictionDaemon` with `withPermissions`, which was the cause of the race condition detailed in [this PR](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/59).
2. Passes the `StudyCard`'s `permissions` prop via the "studies" `Showcase`, instead of wrapping `StudyCard` via `withPermissions`, and updates the StudyCard `isLoading` to be `false` iff the redux `siteData` and `permissions` are loaded. (As [this PR](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/59) details, this improves the loading UX of the "studies" Showcase.)