### PR TITLE
use @veupathdb/study-data-access

### DIFF
--- a/Model/lib/conifer/roles/conifer/vars/ClinEpi/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ClinEpi/default.yml
@@ -10,8 +10,9 @@ modelprop:
   TWITTER_URL: https://twitter.com/ClinEpiDB
   YOUTUBE_URL: https://www.youtube.com/playlist?list=PLWzQB3i5sYAIp4urzLGB8jxvVZr6jvkZh
   CLINEPI_ACCESS_REQUEST_EMAIL: help@clinepidb.org
-  USE_EDA: "true"
-  EDA_EXAMPLE_ANALYSES_AUTHOR: 854899613
+eda:
+  enabled: "true"
+  example_analyses_author: 854899613
 modelconfig_oauthUrl: https://eupathdb.org/oauth
 modelconfig_authenticationMethod: oauth2
 modelconfig_oauthClientId: apiComponentSite

--- a/Site/webapp/js/client/component-wrappers/Page.tsx
+++ b/Site/webapp/js/client/component-wrappers/Page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Props } from '@veupathdb/wdk-client/lib/Components/Layout/Page';
 
-import { useAttemptActionClickHandler } from '@veupathdb/web-common/lib/hooks/dataRestriction';
+import { useAttemptActionClickHandler } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
 
 export function Page(DefaultComponent: React.ComponentType<Props>) {
   return function ClinEpiPage(props: Props) {

--- a/Site/webapp/js/client/component-wrappers/SiteHeader.jsx
+++ b/Site/webapp/js/client/component-wrappers/SiteHeader.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useSessionBackedState } from '@veupathdb/wdk-client/lib/Hooks/SessionBackedState';
 import Header from '@veupathdb/web-common/lib/App/Header';
-import { DataRestrictionDaemon } from '@veupathdb/web-common/lib/App/DataRestriction';
+import { makeEdaRoute } from '@veupathdb/web-common/lib/routes';
+import { DataRestrictionDaemon } from '@veupathdb/study-data-access/lib/data-restriction';
 import DisclaimerModal from '../components/DisclaimerModal';
 
 import makeHeaderMenuItems from '../data/headerMenuItems';
@@ -28,7 +29,7 @@ export default function SiteHeaderWrapper() {
           setSearchTerm={setSearchTerm}
         />
         <DisclaimerModal />
-        <DataRestrictionDaemon />
+        <DataRestrictionDaemon makeStudyPageRoute={id => makeEdaRoute(id) + '/details'} />
       </React.Fragment>
     )
   }

--- a/Site/webapp/js/client/component-wrappers/index.js
+++ b/Site/webapp/js/client/component-wrappers/index.js
@@ -10,8 +10,8 @@ import {
   getIdFromRecordClassName,
   isStudyRecordClass,
   Action
-} from '@veupathdb/web-common/lib/App/DataRestriction/DataRestrictionUtils';
-import { attemptAction } from '@veupathdb/web-common/lib/App/DataRestriction/DataRestrictionActionCreators';
+} from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
+import { attemptAction } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionActionCreators';
 import { fetchStudies } from '@veupathdb/web-common/lib/App/Studies/StudyActionCreators';
 
 import RelativeVisitsGroup from '../components/RelativeVisitsGroup';

--- a/Site/webapp/js/client/main.js
+++ b/Site/webapp/js/client/main.js
@@ -5,7 +5,7 @@ import '@veupathdb/web-common/lib/styles/client.scss';
 import componentWrappers from './component-wrappers';
 import wrapStoreModules from './wrapStoreModules';
 import { wrapRoutes } from './routes';
-import { reduxMiddleware } from '@veupathdb/web-common/lib/App/DataRestriction/DataRestrictionUtils'
+import { reduxMiddleware } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils'
 
 import 'site/css/ClinEpiSite.scss';
 


### PR DESCRIPTION
Note that we are "borrowing" `@veupathdb/study-data-access` from EbrcwebsiteCommon. What I mean by this is, the dependency is not installed directly in this packages `node_modules` directory. Doing so adds additional complications to the build process, and it's a practice we've had in place for a while.

related to https://github.com/VEuPathDB/web-eda/issues/662