### PR TITLE
Adding ISA diy user dataset handler to ClinEpi config

### DIFF
--- a/Model/lib/conifer/roles/conifer/vars/ClinEpi/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ClinEpi/default.yml
@@ -28,3 +28,10 @@ modelconfig_oauthClientSecret: "{{ lookup('csvfile',
     delimiter=:') | trim
   }}"
 modelconfig_changePasswordUrl: "{{ modelconfig_oauthUrl }}/assets/eupathdb-changePassword.html?returnUrl={{ '{{' }}returnUrl}}&amp;suggestedUsername={{ '{{' }}suggestedUsername}}"
+
+modelconfig_userDatasetStoreConfig: >
+  <userDatasetStore implementation="org.gusdb.wdk.model.user.dataset.filesys.FilesysUserDatasetStore">
+    <property name="rootPath">/var/www/Common/workspaces/users</property>
+    <typeHandler type="ISA" version="0.0"
+      implementation="org.apidb.apicommon.model.userdataset.ISASimpleTypeHandler"/>
+  </userDatasetStore>

--- a/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
@@ -90,9 +90,7 @@ modelconfig_userDatasetStoreConfig_irods_rootPath: "{{ workspace_env['rootPath']
 modelconfig_userDatasetStoreConfig_irods_zone: "{{ workspace_env['zone'] }}"
 modelconfig_userDatasetStoreConfig_irods_port: "{{ workspace_env['port'] }}"
 
-# The implementation of the UserDatasetStore goes largely unused in the site.
-# The TypeHandlers are the only part of the store that are currently used outside
-# the installer, which is run as a dedicated Jenkins job with its own conifer config.
+# The IrodsUserDatasetStore implementation is needed to connect to IRODS and list user datasets in WDK sites.
 modelconfig_userDatasetStoreConfig: >
   <userDatasetStore implementation="org.gusdb.wdk.model.user.dataset.irods.IrodsUserDatasetStore">
    <property name="login">{{ modelconfig_userDatasetStoreConfig_irods_login }}</property>

--- a/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
@@ -45,8 +45,11 @@ community_env_map:
   b_prefix: static-content.veupathdb.org/
   default: qa.static-content.veupathdb.org/
 
+# The implementation of the UserDatasetStore goes largely unused in the site.
+# The TypeHandlers are the only part of the store that are currently used outside
+# the installer, which is run as a dedicated Jenkins job with its own conifer config.
 modelconfig_userDatasetStoreConfig: >
-  <userDatasetStore implementation="org.gusdb.wdk.model.user.dataset.filesys.FilesysUserDatasetStore">
+  <userDatasetStore implementation="org.gusdb.wdk.model.user.dataset.irods.IrodsUserDatasetStore">
     <property name="rootPath">/var/www/Common/workspaces/users</property>
     <typeHandler type="ISA" version="0.0"
       implementation="org.apidb.apicommon.model.userdataset.ISASimpleTypeHandler"/>

--- a/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
@@ -45,12 +45,62 @@ community_env_map:
   b_prefix: static-content.veupathdb.org/
   default: qa.static-content.veupathdb.org/
 
+workspace_env_map:
+  b_prefix:
+    host: irods.eupathdb.org
+    login: wrkspuser
+    password: "{{ lookup('euparc',
+      'attr=password xpath=workspaces/irods[@user=\"{}\"]'.format('wrkspuser')
+      )
+    }}"
+    resource: ebrcResc
+    rootPath: /ebrc/workspaces/users
+    zone: ebrc
+    port: 1247
+  w_prefix:
+    host: irods.eupathdb.org
+    login: wrkspuser
+    password: "{{ lookup('euparc',
+      'attr=password xpath=workspaces/irods[@user=\"{}\"]'.format('wrkspuser')
+      )
+    }}"
+    resource: ebrcResc
+    rootPath: /ebrc/workspaces/users
+    zone: ebrc
+    port: 1247
+  default:
+    host: irods.qa.eupathdb.org
+    login: qawrkspuser
+    password: "{{ lookup('euparc',
+      'attr=password xpath=workspaces/irods[@user=\"{}\"]'.format('qawrkspuser')
+      )
+    }}"
+    resource: ebrcResc
+    rootPath: /ebrc/workspaces/users
+    zone: ebrc
+    port: 1247
+
+workspace_env: "{{ workspace_env_map[prefix]|default(workspace_env_map['default']) }}"
+
+modelconfig_userDatasetStoreConfig_irods_host: "{{ workspace_env['host'] }}"
+modelconfig_userDatasetStoreConfig_irods_login: "{{ workspace_env['login'] }}"
+modelconfig_userDatasetStoreConfig_irods_password: "{{ workspace_env['password'] }}"
+modelconfig_userDatasetStoreConfig_irods_resource: "{{ workspace_env['resource'] }}"
+modelconfig_userDatasetStoreConfig_irods_rootPath: "{{ workspace_env['rootPath'] }}"
+modelconfig_userDatasetStoreConfig_irods_zone: "{{ workspace_env['zone'] }}"
+modelconfig_userDatasetStoreConfig_irods_port: "{{ workspace_env['port'] }}"
+
 # The implementation of the UserDatasetStore goes largely unused in the site.
 # The TypeHandlers are the only part of the store that are currently used outside
 # the installer, which is run as a dedicated Jenkins job with its own conifer config.
 modelconfig_userDatasetStoreConfig: >
   <userDatasetStore implementation="org.gusdb.wdk.model.user.dataset.irods.IrodsUserDatasetStore">
-    <property name="rootPath">/var/www/Common/workspaces/users</property>
-    <typeHandler type="ISA" version="0.0"
-      implementation="org.apidb.apicommon.model.userdataset.ISASimpleTypeHandler"/>
+   <property name="login">{{ modelconfig_userDatasetStoreConfig_irods_login }}</property>
+   <property name="password">{{ modelconfig_userDatasetStoreConfig_irods_password }}</property>
+   <property name="host">{{ modelconfig_userDatasetStoreConfig_irods_host }}</property>
+   <property name="port">{{ modelconfig_userDatasetStoreConfig_irods_port }}</property>
+   <property name="resource">{{ modelconfig_userDatasetStoreConfig_irods_resource }}</property>
+   <property name="zone">{{ modelconfig_userDatasetStoreConfig_irods_zone }}</property>
+   <property name="rootPath">{{ modelconfig_userDatasetStoreConfig_irods_rootPath }}</property>    
+   <typeHandler type="ISA" version="0.0"  implementation="org.apidb.apicommon.model.userdataset.ISASimpleTypeHandler"/>
   </userDatasetStore>

--- a/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
+++ b/Model/lib/conifer/roles/conifer/vars/ClinEpi/production/default.yml
@@ -44,3 +44,10 @@ community_env_map:
   w_prefix: static-content.veupathdb.org/
   b_prefix: static-content.veupathdb.org/
   default: qa.static-content.veupathdb.org/
+
+modelconfig_userDatasetStoreConfig: >
+  <userDatasetStore implementation="org.gusdb.wdk.model.user.dataset.filesys.FilesysUserDatasetStore">
+    <property name="rootPath">/var/www/Common/workspaces/users</property>
+    <typeHandler type="ISA" version="0.0"
+      implementation="org.apidb.apicommon.model.userdataset.ISASimpleTypeHandler"/>
+  </userDatasetStore>


### PR DESCRIPTION
**In latest revision:**
Tested by adding the config my local conifer site vars and creating the file `~/.euparc`

Validated on dev-site: https://dgaldi.clinepidb.org/ce.dgaldi/service/users/current/user-datasets?expandDetails=true

* Adding ISA dataset type to ClinEpi client configuration
* It appears as though this [handler is used to add type-specific data](https://github.com/VEuPathDB/WDK/blob/6d9815ff6c19cbf078c4ddb18a1349f915e22ff3/Service/src/main/java/org/gusdb/wdk/service/service/user/UserDatasetService.java#L99) when retrieving dataset info.
* In cases where this isn't necessary, it's presence is still needed to indicate this type is supported in the project.