### PR TITLE
Wire up snackbars for ClinEpiDB

### DIFF
--- a/Site/webapp/js/client/component-wrappers/Page.tsx
+++ b/Site/webapp/js/client/component-wrappers/Page.tsx
@@ -7,6 +7,7 @@ import { useAttemptActionClickHandler } from '@veupathdb/study-data-access/lib/d
 import UIThemeProvider from '@veupathdb/coreui/dist/components/theming/UIThemeProvider';
 import { colors } from '@veupathdb/coreui';
 import { useCoreUIFonts } from '@veupathdb/coreui/dist/hooks';
+import makeSnackbarProvider from '@veupathdb/coreui/dist/components/notifications/SnackbarProvider';
 
 export function Page(DefaultComponent: React.ComponentType<Props>) {
   return function ClinEpiPage(props: Props) {
@@ -22,8 +23,28 @@ export function Page(DefaultComponent: React.ComponentType<Props>) {
                 },
               }}
             >
-              <DefaultComponent {...props} />
+              <ClinEpiSnackbarProvider styleProps={{}}>
+                <DefaultComponent {...props} />
+              </ClinEpiSnackbarProvider>
             </UIThemeProvider>
     );
   };
 }
+
+function translateNotificationsOnTop() {
+  return {
+    transform: 'translateY(158px)'
+  };
+}
+
+const ClinEpiSnackbarProvider = makeSnackbarProvider(
+  {
+    containerRoot: {
+      zIndex: 10001,
+    },
+    anchorOriginTopLeft: translateNotificationsOnTop,
+    anchorOriginTopCenter: translateNotificationsOnTop,
+    anchorOriginTopRight: translateNotificationsOnTop,
+  },
+  'ClinEpiSnackbarProvider',
+);


### PR DESCRIPTION
Explanation: `Page` is a "component wrapper" - a function which takes a component and returns an enhanced/decorated version of the component. In this case, `Page` receives the [default "Page" component provided by the WDK client](https://github.com/VEuPathDB/WDKClient/blob/master/Client/src/Components/Layout/Page.tsx), and returns a `ClinEpiPage` component which wraps that "default" component with (1) the Core UI theme (ClinEpi colors) and (2) the SnackbarProvier.