### PR TITLE
Send separate emails for provider/requester

### DIFF
--- a/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestParams.java
+++ b/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestParams.java
@@ -18,6 +18,7 @@ public class AccessRequestParams {
   private final String requestEmailBodyRequester;
   private final String requestEmailBodyManager;
 
+  private final Map<String, String> datasetProperties;
   private final Map<String, String> formFields;
   
   public AccessRequestParams(
@@ -32,6 +33,7 @@ public class AccessRequestParams {
       int approvalType,
       String requestEmailBodyRequester,
       String requestEmailBodyManager,
+      Map<String, String> datasetProperties,
       Map<String, String> formFields) {
     this.testing = testing;
 
@@ -46,6 +48,7 @@ public class AccessRequestParams {
     this.approvalType = approvalType;
     this.requestEmailBodyRequester = requestEmailBodyRequester;
     this.requestEmailBodyManager = requestEmailBodyManager;
+    this.datasetProperties = datasetProperties;
     this.formFields = formFields;
   }
 
@@ -95,6 +98,10 @@ public class AccessRequestParams {
 
   public boolean approvalNeeded() {
     return approvalType != 0;
+  }
+
+  public Map<String, String> getDatasetProperties() {
+    return datasetProperties;
   }
 
   public Map<String, String> getFormFields() {

--- a/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestParams.java
+++ b/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestParams.java
@@ -15,6 +15,9 @@ public class AccessRequestParams {
   private final String bodyTemplate;
   private final int approvalType;
 
+  private final String requestEmailBodyRequester;
+  private final String requestEmailBodyManager;
+
   private final Map<String, String> formFields;
   
   public AccessRequestParams(
@@ -27,6 +30,8 @@ public class AccessRequestParams {
       String bccEmail,
       String bodyTemplate,
       int approvalType,
+      String requestEmailBodyRequester,
+      String requestEmailBodyManager,
       Map<String, String> formFields) {
     this.testing = testing;
 
@@ -39,7 +44,8 @@ public class AccessRequestParams {
     this.bccEmail = bccEmail;
     this.bodyTemplate = bodyTemplate;
     this.approvalType = approvalType;
-
+    this.requestEmailBodyRequester = requestEmailBodyRequester;
+    this.requestEmailBodyManager = requestEmailBodyManager;
     this.formFields = formFields;
   }
 
@@ -78,7 +84,15 @@ public class AccessRequestParams {
   public int getApprovalType() {
     return approvalType;
   }
-  
+
+  public String getRequestEmailBodyRequester() {
+    return requestEmailBodyRequester;
+  }
+
+  public String getRequestEmailBodyManager() {
+    return requestEmailBodyManager;
+  }
+
   public boolean approvalNeeded() {
     return approvalType != 0;
   }

--- a/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
+++ b/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
@@ -2,6 +2,8 @@ package org.clinepi.service.accessRequest;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -22,6 +24,7 @@ import org.gusdb.wdk.model.WdkUserException;
 import org.gusdb.wdk.model.record.PrimaryKeyValue;
 import org.gusdb.wdk.model.record.RecordClass;
 import org.gusdb.wdk.model.record.RecordInstance;
+import org.gusdb.wdk.model.record.attribute.AttributeFieldDataType;
 import org.gusdb.wdk.service.request.RecordRequest;
 import org.gusdb.wdk.service.request.exception.ConflictException;
 import org.gusdb.wdk.service.request.exception.DataValidationException;
@@ -36,6 +39,8 @@ public class AccessRequestService extends UserService {
   private static final String DATASET_RECORD_CLASS = "dataset";
 
   interface DatasetAccessRequestAttributes {
+    Map<String, String> getDatasetProperties();
+
     public String getStudyAccess() throws WdkModelException, WdkUserException;
     public String getDisplayName() throws WdkModelException, WdkUserException;
     public String getRequestEmail() throws WdkModelException, WdkUserException;
@@ -113,6 +118,13 @@ public class AccessRequestService extends UserService {
       }
 
       @Override
+      public Map<String, String> getDatasetProperties() {
+        return record.getAttributeFieldMap().entrySet().stream()
+            .filter(e -> e.getValue().getDataType() == AttributeFieldDataType.STRING)
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+      }
+
+      @Override
       public String getStudyAccess() throws WdkModelException, WdkUserException {
       // return getAttributeValueString("restriction_level");
       // the form does not currently include the user request for a specific study access, we always grant public access
@@ -184,6 +196,7 @@ public class AccessRequestService extends UserService {
       datasetAttributes.getRequestNeedsApproval(),
       datasetAttributes.getRequestEmailBodyRequester(),
       datasetAttributes.getRequestEmailBodyManager(),
+      datasetAttributes.getDatasetProperties(),
       JsonUtil.parseProperties(requestJson)
     );
   }

--- a/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
+++ b/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
@@ -119,9 +119,15 @@ public class AccessRequestService extends UserService {
 
       @Override
       public Map<String, String> getDatasetProperties() {
-        return record.getAttributeFieldMap().entrySet().stream()
-            .filter(e -> e.getValue().getDataType() == AttributeFieldDataType.STRING)
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+        return record.entrySet().stream()
+            .filter(e -> e.getValue().getAttributeField().getDataType() == AttributeFieldDataType.STRING)
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> {
+              try {
+                return e.getValue().getValue();
+              } catch (Exception ex) {
+                throw new RuntimeException(ex);
+              }
+            }));
       }
 
       @Override

--- a/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
+++ b/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
@@ -123,7 +123,7 @@ public class AccessRequestService extends UserService {
             .filter(e -> e.getValue().getAttributeField().getDataType() == AttributeFieldDataType.STRING)
             .collect(Collectors.toMap(Map.Entry::getKey, e -> {
               try {
-                return e.getValue().getValue();
+                return e.getValue().getValue() != null ? e.getValue().getValue() : "";
               } catch (Exception ex) {
                 throw new RuntimeException(ex);
               }

--- a/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
+++ b/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestService.java
@@ -42,6 +42,8 @@ public class AccessRequestService extends UserService {
     public String getRequestEmailBcc() throws WdkModelException, WdkUserException;
     public String getRequestEmailBody() throws WdkModelException, WdkUserException;
     public Integer getRequestNeedsApproval() throws WdkModelException, WdkUserException;
+    String getRequestEmailBodyManager() throws WdkModelException, WdkUserException;
+    String getRequestEmailBodyRequester() throws WdkModelException, WdkUserException;
   }
 
   public AccessRequestService(@PathParam(USER_ID_PATH_PARAM) String userId) {
@@ -141,6 +143,16 @@ public class AccessRequestService extends UserService {
       public Integer getRequestNeedsApproval() throws NumberFormatException, WdkModelException, WdkUserException {
         return Integer.parseInt(getAttributeValueString("request_needs_approval"));
       }
+
+      @Override
+      public String getRequestEmailBodyManager() throws WdkModelException, WdkUserException {
+        return getAttributeValueString("request_email_body_manager");
+      }
+
+      @Override
+      public String getRequestEmailBodyRequester() throws WdkModelException, WdkUserException {
+        return getAttributeValueString("request_email_body_requester");
+      }
     };
   }
 
@@ -170,6 +182,8 @@ public class AccessRequestService extends UserService {
       datasetAttributes.getRequestEmailBcc(),
       datasetAttributes.getRequestEmailBody(),
       datasetAttributes.getRequestNeedsApproval(),
+      datasetAttributes.getRequestEmailBodyRequester(),
+      datasetAttributes.getRequestEmailBodyManager(),
       JsonUtil.parseProperties(requestJson)
     );
   }

--- a/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestSubmitter.java
+++ b/Site/src/main/java/org/clinepi/service/accessRequest/AccessRequestSubmitter.java
@@ -141,8 +141,8 @@ public class AccessRequestSubmitter {
       datasetName
     );
     LOG.debug("emailAccessRequest() -- here are the formFields: " + formFields);
-    String requesterBody = createAccessRequestEmailBody(bodyTemplate, formFields, datasetName);
-    String managerBody = createAccessRequestEmailBody(params.getRequestEmailBodyManager(), formFields, datasetName);
+    String requesterBody = createAccessRequestEmailBody(bodyTemplate + params.getRequestEmailBodyRequester(), formFields, datasetName);
+    String managerBody = createAccessRequestEmailBody(bodyTemplate + params.getRequestEmailBodyManager(), formFields, datasetName);
 
     String metaInfo =
         "ReplyTo: " + requesterEmail + "\n" +


### PR DESCRIPTION
Start using new dataset properties for provider/requester e-mail bodies. Starting in draft mode because i'm not sure if there's a safe way to test on dev site.

Resolves https://github.com/VEuPathDB/EdaNewIssues/issues/670

Here's what it looks like with what we currently have configured for MAL-ED:

<img width="1756" alt="Screenshot 2023-08-28 at 2 23 28 PM" src="https://github.com/VEuPathDB/ClinEpiWebsite/assets/3497580/dffa3861-e6dc-4899-be9c-9160f1870d88">

